### PR TITLE
[BE] 예외별 StatusCode 변경 | {feature/statuscode} => {BE}

### DIFF
--- a/src/main/java/com/imagine/another_arts/domain/art/repository/ArtRepository.java
+++ b/src/main/java/com/imagine/another_arts/domain/art/repository/ArtRepository.java
@@ -12,13 +12,15 @@ import java.util.Optional;
 
 public interface ArtRepository extends JpaRepository<Art, Long> {
 
+    boolean existsByName(String name);
+
     @Query("SELECT a" +
             " FROM Art a" +
             " JOIN FETCH a.user" +
             " WHERE a.id = :artId")
     Optional<Art> findFirstArtBy(@Param("artId") Long artId);
 
-    Optional<Art> findFirstByIdNotAndName(Long artId, String name);
+    boolean existsByIdNotAndName(Long artId, String name);
 
     // RegisterDate or BidPrice or BidCount 기준 정렬 (N+1로 인해서 정렬 조회 시 Art-User 따로 fetch join)
     @Query("SELECT a" +

--- a/src/main/java/com/imagine/another_arts/domain/arthashtag/repository/ArtHashtagRepository.java
+++ b/src/main/java/com/imagine/another_arts/domain/arthashtag/repository/ArtHashtagRepository.java
@@ -1,6 +1,8 @@
 package com.imagine.another_arts.domain.arthashtag.repository;
 
+import com.imagine.another_arts.domain.art.Art;
 import com.imagine.another_arts.domain.arthashtag.ArtHashtag;
+import com.imagine.another_arts.domain.hashtag.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,4 +19,6 @@ public interface ArtHashtagRepository extends JpaRepository<ArtHashtag, Long> {
     List<ArtHashtag> findByArtId(Long artId);
 
     Optional<ArtHashtag> findByArtIdAndHashtagName(Long artId, String name);
+
+    boolean existsByArtAndHashtag(Art art, Hashtag hashtag);
 }

--- a/src/main/java/com/imagine/another_arts/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/imagine/another_arts/domain/auction/repository/AuctionRepository.java
@@ -1,5 +1,6 @@
 package com.imagine.another_arts.domain.auction.repository;
 
+import com.imagine.another_arts.domain.art.Art;
 import com.imagine.another_arts.domain.auction.Auction;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -7,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
+
+    Auction findByArt(Art art);
 
     @Query(value = "SELECT *" +
                     " FROM auction ac" +
@@ -18,7 +19,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
                     " LEFT OUTER JOIN users u2 on ac.user_id = u2.user_id" +
                     " WHERE a.sale_type = 'AUCTION' AND a.art_id = :artId",
             nativeQuery = true)
-    Optional<Auction> findFirstAuctionBy(@Param("artId") Long artId);
+    Auction findFirstAuctionBy(@Param("artId") Long artId);
 
     // RegisterDateDESC
     @Query(value = "SELECT ac.*, u1.user_id, u1.nickname, u1.school_name, a.art_id, a.name, a.description, a.init_price," +

--- a/src/main/java/com/imagine/another_arts/domain/auctionhistory/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/imagine/another_arts/domain/auctionhistory/repository/AuctionHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.imagine.another_arts.domain.auctionhistory.repository;
 
+import com.imagine.another_arts.domain.art.Art;
 import com.imagine.another_arts.domain.auctionhistory.AuctionHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,6 @@ public interface AuctionHistoryRepository extends JpaRepository<AuctionHistory, 
             " JOIN FETCH ah.user" +
             " JOIN FETCH ah.auction")
     List<AuctionHistory> findAuctionHistoriesBy();
+
+    boolean existsByArtAndUserIsNotNull(Art art);
 }

--- a/src/main/java/com/imagine/another_arts/domain/purchase/repository/PurchaseHistoryRepository.java
+++ b/src/main/java/com/imagine/another_arts/domain/purchase/repository/PurchaseHistoryRepository.java
@@ -1,10 +1,9 @@
 package com.imagine.another_arts.domain.purchase.repository;
 
+import com.imagine.another_arts.domain.art.Art;
 import com.imagine.another_arts.domain.purchase.PurchaseHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Long> {
-    Optional<PurchaseHistory> findFirstByArtId(Long artId);
+    boolean existsByArt(Art art);
 }

--- a/src/main/java/com/imagine/another_arts/exception/DuplicationArtNameException.java
+++ b/src/main/java/com/imagine/another_arts/exception/DuplicationArtNameException.java
@@ -1,0 +1,23 @@
+package com.imagine.another_arts.exception;
+
+public class DuplicationArtNameException extends RuntimeException {
+    public DuplicationArtNameException() {
+        super();
+    }
+
+    public DuplicationArtNameException(String message) {
+        super(message);
+    }
+
+    public DuplicationArtNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DuplicationArtNameException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DuplicationArtNameException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/imagine/another_arts/exception/UnAuthenticatedUserException.java
+++ b/src/main/java/com/imagine/another_arts/exception/UnAuthenticatedUserException.java
@@ -1,0 +1,23 @@
+package com.imagine.another_arts.exception;
+
+public class UnAuthenticatedUserException extends RuntimeException {
+    public UnAuthenticatedUserException() {
+        super();
+    }
+
+    public UnAuthenticatedUserException(String message) {
+        super(message);
+    }
+
+    public UnAuthenticatedUserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnAuthenticatedUserException(Throwable cause) {
+        super(cause);
+    }
+
+    protected UnAuthenticatedUserException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/imagine/another_arts/web/art/ArtController.java
+++ b/src/main/java/com/imagine/another_arts/web/art/ArtController.java
@@ -3,14 +3,15 @@ package com.imagine.another_arts.web.art;
 import com.imagine.another_arts.domain.art.service.ArtService;
 import com.imagine.another_arts.domain.art.service.dto.AuctionArtResponse;
 import com.imagine.another_arts.exception.ArtNotFoundException;
-import com.imagine.another_arts.web.SimpleSucessResponse;
 import com.imagine.another_arts.web.art.dto.*;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -24,20 +25,28 @@ public class ArtController {
     private final ArtService artService;
     private static final int SLICE_PER_PAGE = 20;
 
-    @PostMapping(value = "/register/auctionart", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/art/auction", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "경매 작품 등록 API", notes = "경매 전용 작품 등록 (multipart/form-data) -> 폼 데이터 전부 작성 (NOT NULL)")
-    public SimpleSucessResponse registerAuctionArt(AuctionArtRegisterRequest auctionArtRegisterRequest) {
-        artService.registerAuctionArt(auctionArtRegisterRequest.toServiceDto());
-        return new SimpleSucessResponse(true);
+    public ResponseEntity<SimpleArtSuccessResponse> registerAuctionArt(AuctionArtRegisterRequest auctionArtRegisterRequest) {
+        Long saveArtId = artService.registerAuctionArt(auctionArtRegisterRequest.toServiceDto());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Location", "/api/art/" + saveArtId);
+
+        return new ResponseEntity<>(new SimpleArtSuccessResponse(saveArtId), headers, HttpStatus.CREATED);
     }
 
-    @PostMapping(value = "/register/generalart", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/art/general", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "일반 작품 등록 API", notes = "일반 판매용 작품 등록 (multipart/form-data) -> 폼 데이터 전부 작성 (NOT NULL)")
-    public SimpleSucessResponse registerGeneralArt(GeneralArtRegisterRequest generalArtRegisterRequest) {
-        artService.registerGeneralArt(generalArtRegisterRequest.toServiceDto());
-        return new SimpleSucessResponse(true);
+    public ResponseEntity<SimpleArtSuccessResponse> registerGeneralArt(GeneralArtRegisterRequest generalArtRegisterRequest) {
+        Long saveArtId = artService.registerGeneralArt(generalArtRegisterRequest.toServiceDto());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Location", "/api/art/" + saveArtId);
+
+        return new ResponseEntity<>(new SimpleArtSuccessResponse(saveArtId), headers, HttpStatus.CREATED);
     }
 
     @GetMapping("/art/{artId}")
@@ -46,41 +55,41 @@ public class ArtController {
         return new SpecificArtResponse<>(true, artService.getSpecificArt(artId));
     }
 
-    @PutMapping("/edit/art/{artId}")
+    @PatchMapping("/art/{artId}")
     @ApiOperation(value = "작품 정보 변경 API", notes = "작품명, 작품 설명 변경")
-    public SimpleSucessResponse editArt(
+    public ResponseEntity<Void> editArt(
             @PathVariable Long artId,
             @ModelAttribute ArtEditRequest artEditRequest
     ) {
         artService.editArt(artId, artEditRequest.toServiceDto());
-        return new SimpleSucessResponse(true);
+        return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/delete/art/{artId}")
+    @DeleteMapping("/art/{artId}")
     @ApiOperation(value = "작품 삭제 API", notes = "작품 삭제 (경매 작품은 삭제 불가능)")
-    public SimpleSucessResponse deleteArt(@PathVariable Long artId) {
+    public ResponseEntity<Void> deleteArt(@PathVariable Long artId) {
         artService.deleteArt(artId);
-        return new SimpleSucessResponse(true);
+        return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/add/hashtag/{artId}")
+    @PatchMapping("/hashtag/{artId}")
     @ApiOperation(value = "작품 해시태그 추가 API", notes = "일반 판매용 작품 등록 (multipart/form-data)")
-    public SimpleSucessResponse addHashtag(
+    public ResponseEntity<Void> addHashtag(
             @PathVariable Long artId,
             @Valid @ModelAttribute HashtagListRequest hashtagListRequest
     ) {
         artService.addHashtag(artId, hashtagListRequest.getHashtagList());
-        return new SimpleSucessResponse(true);
+        return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/delete/hashtag/{artId}")
+    @DeleteMapping("/hashtag/{artId}")
     @ApiOperation(value = "작품 해시태그 삭제 API", notes = "작품의 해시태그 리스트중에 삭제할 해시태그를 삭제 요청")
-    public SimpleSucessResponse deleteHashtag(
+    public ResponseEntity<Void> deleteHashtag(
             @PathVariable Long artId,
             @RequestParam @ApiParam(value = "삭제할 해시태그", required = true) String hashtag
     ) {
         artService.deleteHashtag(artId, hashtag);
-        return new SimpleSucessResponse(true);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/main/art")

--- a/src/main/java/com/imagine/another_arts/web/art/ArtExceptionHandler.java
+++ b/src/main/java/com/imagine/another_arts/web/art/ArtExceptionHandler.java
@@ -18,12 +18,12 @@ public class ArtExceptionHandler {
         );
     }
 
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(UserNotFoundException.class)
-    public ErrorDescription userNotFoundException(UserNotFoundException e) {
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnAuthenticatedUserException.class)
+    public ErrorDescription unAuthenticatedUserException(UnAuthenticatedUserException e) {
         return new ErrorDescription(
                 false,
-                "NOT_FOUND",
+                "UNAUTHORIZED",
                 e.getMessage()
         );
     }
@@ -48,16 +48,6 @@ public class ArtExceptionHandler {
         );
     }
 
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(AuctionNotFoundException.class)
-    public ErrorDescription auctionNotFoundException(AuctionNotFoundException e) {
-        return new ErrorDescription(
-                false,
-                "NOT_FOUND",
-                e.getMessage()
-        );
-    }
-
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalHashtagDeleteException.class)
     public ErrorDescription illegalHashtagDeleteException(IllegalHashtagDeleteException e) {
@@ -68,22 +58,32 @@ public class ArtExceptionHandler {
         );
     }
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(IllegalArtModifyException.class)
     public ErrorDescription illegalArtEditException(IllegalArtModifyException e) {
         return new ErrorDescription(
                 false,
-                "BAD_REQUEST",
+                "CONFLICT",
                 e.getMessage()
         );
     }
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(IllegalArtDeleteException.class)
     public ErrorDescription illegalArtDeleteException(IllegalArtDeleteException e) {
         return new ErrorDescription(
                 false,
-                "BAD_REQUEST",
+                "CONFLICT",
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(DuplicationArtNameException.class)
+    public ErrorDescription duplicationArtNameException(DuplicationArtNameException e) {
+        return new ErrorDescription(
+                false,
+                "CONFLICT",
                 e.getMessage()
         );
     }

--- a/src/main/java/com/imagine/another_arts/web/art/dto/SimpleArtSuccessResponse.java
+++ b/src/main/java/com/imagine/another_arts/web/art/dto/SimpleArtSuccessResponse.java
@@ -1,0 +1,10 @@
+package com.imagine.another_arts.web.art.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SimpleArtSuccessResponse {
+    private Long artId;
+}


### PR DESCRIPTION
## Response
#### 작품 등록 Response
- 이전에는 "true"라는 boolean값으로 등록 여부를 응답해주었다
- 변경된 부분에서는 <code>ResponseEntity의 Body</code>에 <code>등록된 Art의 PK값을 담은 SimpleArtSuccessResponse</code>를 넣어주고 <code>Response Header의 Content-Location</code>에는 새로 등록된 Art에 대해서 요청할 수 있는 <code>Resource Path</code>를 넣어주었다

#### 작품 수정/삭제, 해시태그 추가/삭제 Response
- 변경이나 삭제에 대한 Request를 처리하고 Response를 할 때 굳이 Body에 내용을 담아서 전달할 필요가 없다고 생각해서 <code>204 NO_CONTENT</code>로 응답
<hr>

## Exception Handling
#### UserNotFoundException (NOT_FOUND) -> UnAuthenticatedUserException (UNAUTHORIZED)
- DB에 없는 사용자가 작품을 등록하는 경우 해당 사용자는 시스템에 가입을 하지 않은(인증 되지 않은) 사용자이므로 <code>404 NOT_FOUND</code>보다 <code>401 UNAUTHORIZED</code>가 더 적합하다고 판단
> 401 UNAUTHORIZED = <code>인증</code>자체가 되지 않은 사용자에 대한 제어
> 403 FORBIDDEN = 인증은 되었지만 해당 URL로 Request를 보낼 <code>권한</code>이 없는 것에 대한 제어

#### IllegalArtModifyException, IllegalArtDeleteException, DuplicationArtNameException : NOT_FOUND(404) -> CONFLICT(409)
- <code>404 NOT_FOUND</code>는 Client의 Request에 대해서 Server에서 처리할때 <code>관련된 리소스를 찾지 못할 때</code> 던지는 예외이다. 위의 3가지 예외는 각각 <code>작품에 대한 수정/삭제 시 발생하는 예외</code>이고, 이는 <code>DB의 Unique Key, Business Logic과 관련된 예외</code>이므로 404 NOT_FOUND보다는 <code>현재 Resource와 그에 대한 Request간의 충돌을 나타내는 409 CONFLICT</code>가 더 적합하다고 판단

